### PR TITLE
(https://github.com/ansible-community/molecule/issues/2759) に対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .tox
 *.egg-info
+molecule/common/cache/host_vars/*
+!molecule/common/cache/host_vars/.gitkeep

--- a/molecule/common/base.yml
+++ b/molecule/common/base.yml
@@ -19,7 +19,8 @@ provisioner:
     diff: true
   inventory:
     links:
-      group_vars: group_vars
+      host_vars: ${HOST_VARS}
+      group_vars: ${GROUP_VARS}
 
 verifier:
   name: testinfra

--- a/molecule/common/base.yml
+++ b/molecule/common/base.yml
@@ -24,7 +24,8 @@ provisioner:
 
 verifier:
   name: testinfra
-  directory: ${TESTINFRA_DIR}
+  additional_files_or_dirs:
+    - ${TESTINFRA_DIR}
   options:
     s: true  # pytest の -s を有効化. テスト時に print() の標準出力結果を見るため.
     v: true

--- a/molecule/common/group_vars/all/00-defaults.yml
+++ b/molecule/common/group_vars/all/00-defaults.yml
@@ -1,0 +1,1 @@
+../../../../../defaults/main.yml

--- a/molecule/common/playbooks/converge.yml
+++ b/molecule/common/playbooks/converge.yml
@@ -2,5 +2,9 @@
 - name: Converge
   hosts: all
   become: yes
+  tasks:
+    - name: Check local_ipv4
+      debug:
+        var: local_ipv4
   roles:
     - { role: "{{ (playbook_dir ~ '/../../../..') | realpath }}" }

--- a/molecule/common/playbooks/create.yml
+++ b/molecule/common/playbooks/create.yml
@@ -21,8 +21,29 @@
         timeout: 600
       loop: "{{ molecule_yml.platforms }}"
 
-    - name: Create IPVLAN
-      command: >-
-        lxc exec {{ item.name }} -- ip a add {{ item.local_ipv4 }} dev eth0
-      when: item.local_ipv4 is defined
+    - name: Create host_vars each host directory
+      file:
+        state: "directory"
+        path: >-
+          {{ (molecule_yml.provisioner.inventory.links.host_vars
+              ~ '/' ~ item.name) | realpath }}
+        mode: "0755"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Create host_vars each host files
+      copy:
+        content: "{{ __host_vars | to_nice_yaml }}"
+        dest: >-
+          {{ (molecule_yml.provisioner.inventory.links.host_vars
+              ~ '/' ~ item.name ~
+              '/00-create-by-molecule.yml') | realpath }}
+        mode: "0644"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+      vars:
+        - __host_vars: >-
+            {{ { 'local_ipv4': item.name ~ '.lxd' } |
+              combine(item.host_vars | default({}), recursive=True) }}
       loop: "{{ molecule_yml.platforms }}"

--- a/molecule/common/playbooks/create.yml
+++ b/molecule/common/playbooks/create.yml
@@ -13,8 +13,7 @@
           type: "{{ item.source.type | default('image') }}"
           mode: "{{ item.source.mode | default('pull') }}"
           server: >-
-            {{ item.source.server |
-               default('https://images.linuxcontainers.org') }}
+            {{ item.source.server | default('https://images.linuxcontainers.org') }}
           protocol: "{{ item.source.protocol | default('lxd') }}"
           alias: "{{ item.source.alias }}"
         profiles: ["default"]

--- a/molecule/common/playbooks/destroy.yml
+++ b/molecule/common/playbooks/destroy.yml
@@ -11,3 +11,11 @@
         state: absent
         force_stop: "{{ item.force_stop | default(true) }}"
       loop: "{{ molecule_yml.platforms }}"
+
+    - name: Delete host_vars each host directory
+      file:
+        path: >-
+          {{ (molecule_yml.provisioner.inventory.links.host_vars
+              ~ '/' ~ item.name) | realpath }}
+        state: "absent"
+      loop: "{{ molecule_yml.platforms }}"

--- a/scripts/molecule.py
+++ b/scripts/molecule.py
@@ -30,11 +30,22 @@ if __name__ == "__main__":
     else:
         tests_dir = repo_root_dir + "/molecule/common/tests"
 
+
+    ## group_vars
+    __group_vars_dir = repo_root_dir + "/../molecule/common/group_vars"
+    if os.path.exists(__group_vars_dir) and os.path.isdir(__group_vars_dir):
+        group_vars_dir = os.path.abspath(__group_vars_dir)
+    else:
+        group_vars_dir = repo_root_dir + "/molecule/common/group_vars"
+
+
     ## Add env
     env = os.environ
     env["CREATE_YML"]    = repo_root_dir + "/molecule/common/playbooks/create.yml"
     env["DESTROY_YML"]   = repo_root_dir + "/molecule/common/playbooks/destroy.yml"
     env["CONVERGE_YML"]  = repo_root_dir + "/molecule/common/playbooks/converge.yml"
+    env["HOST_VARS"]     = repo_root_dir + "/molecule/common/cache/host_vars/"
+    env["GROUP_VARS"]    = group_vars_dir
     env["TESTINFRA_DIR"] = tests_dir
     env["ROLE_DIR"]      = os.path.abspath(repo_root_dir + "/..")
 


### PR DESCRIPTION
### 変更点

* 以下の2つの機能を同時に使えるように対応 (https://github.com/ansible-community/molecule/issues/2759)
  * `group_vars` をパスで指定
  * `host_vars` を molecule.yml 内に記述

* ホスト変数 `local_ipv4` をデフォルトで用意
  * デフォルトでは `local_ipv4=<インスタンス名>` としている.
  * また, ipvlan は廃止した (自鯖での Jenkins や セルフホストランナー使用時に IP 被り問題が発生するため)

* ディレクトリの指定方法を `additional_files_or_dirs` に変更 (https://github.com/link-u/ansible-ci-module/pull/2/commits/79cefa66081355f4ef2fe32d227422c579078fbb)

### 参考
* https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#splitting-out-vars
* https://molecule.readthedocs.io/en/latest/configuration.html#testinfra
