### PR TITLE
github actions におけるマトリックスジョブを拡張するための機能を追加

### DIFF
--- a/github_workflow_samples/ansible-ci.yml
+++ b/github_workflow_samples/ansible-ci.yml
@@ -1,0 +1,64 @@
+name: ansible ci
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - v*
+
+jobs:
+  create-matrix:
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Install pip3 and tox
+        run: |
+          sudo apt update
+          sudo apt -y install python3 python3-pip python3-setuptools
+          sudo pip3 install tox
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Create tox env list
+        id: set-matrix
+        run: |
+          MATRIX=$(python3 ansible-ci-module/scripts/matrix.py)
+          echo "::set-output name=matrix::${MATRIX}"
+
+  ansible-ci:
+    needs: create-matrix
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+      fail-fast: False
+    steps:
+      - name: Install LXD and CI tools
+        run: |
+          sudo apt update
+          sudo apt install lxd lxd-tools qemu-block-extra python3 python3-pip python3-setuptools
+
+      - name: Configure LXD
+        run: |
+          sudo lxd init --auto
+
+      - name: Install tox using python3-pip
+        run: |
+          sudo pip3 install tox
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: ansible-ci
+        run: |
+          if [ -f ./tox.ini ]; then
+            sudo MOLECULE_SCENARIO=${{ matrix.scenario }} tox -e ${{ matrix.tox_env }} -c tox.ini
+          else
+            sudo MOLECULE_SCENARIO=${{ matrix.scenario }} tox -e ${{ matrix.tox_env }} -c ansible-ci-module/tox.ini
+          fi

--- a/scripts/matrix.py
+++ b/scripts/matrix.py
@@ -2,6 +2,7 @@
 import os
 import subprocess
 import glob
+import json
 
 ## python script path and repo dir
 script_path   = os.path.abspath(__file__)
@@ -47,8 +48,8 @@ def matrix_scenarios():
 
 
 if __name__ == "__main__":
-    print("{" +
-        "\"tox_env\": [\"" + "\", \"".join(matrix_tox_envs()) + "\"], " +
-        "\"scenario\": [\"" + "\", \"".join(matrix_scenarios()) + "\"]" +
-        "}"
-    )
+    matrix_json = {
+        "tox_env": matrix_tox_envs(),
+        "scenario": matrix_scenarios()
+    }
+    print(json.dumps(matrix_json))

--- a/scripts/matrix.py
+++ b/scripts/matrix.py
@@ -5,12 +5,12 @@ import glob
 
 ## python script path and repo dir
 script_path   = os.path.abspath(__file__)
-repo_root_dir = os.path.abspath(os.path.dirname(script_path) + "/..")
+repo_root_dir = os.path.abspath(os.path.join(os.path.dirname(script_path), ".."))
 
 def matrix_tox_envs():
     ## Execute dir
-    if os.path.isfile(repo_root_dir + "/../tox.ini"):
-        execute_dir = os.path.abspath(repo_root_dir + "/..")
+    if os.path.isfile(os.path.join(repo_root_dir, "..", "tox.ini")):
+        execute_dir = os.path.abspath(os.path.join(repo_root_dir, ".."))
     else:
         execute_dir = repo_root_dir
 
@@ -29,14 +29,14 @@ def matrix_scenarios():
     ## シナリオのリスト (ansible role ディレクトリで定義されているもの)
     scenarios_defined_by_role = [
         os.path.basename(os.path.dirname(p)) for p
-        in glob.glob(repo_root_dir + "/../molecule/*/molecule.yml")
+        in glob.glob(os.path.join(repo_root_dir, "..", "molecule", "*", "molecule.yml"))
         if os.path.isfile(p)
     ]
 
     ## シナリオのリスト (ansible-ci-module 内でデフォルトで定義してあるもの)
     scenarios_in_ansible_ci_modules = [
         os.path.basename(os.path.dirname(p)) for p
-        in glob.glob(repo_root_dir + "/molecule/*/molecule.yml")
+        in glob.glob(os.path.join(repo_root_dir, "molecule", "*", "molecule.yml"))
         if os.path.isfile(p)
     ]
 

--- a/scripts/matrix.py
+++ b/scripts/matrix.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+import os
+import subprocess
+import glob
+
+## python script path and repo dir
+script_path   = os.path.abspath(__file__)
+repo_root_dir = os.path.abspath(os.path.dirname(script_path) + "/..")
+
+def matrix_tox_envs():
+    ## Execute dir
+    if os.path.isfile(repo_root_dir + "/../tox.ini"):
+        execute_dir = os.path.abspath(repo_root_dir + "/..")
+    else:
+        execute_dir = repo_root_dir
+
+    ## Echo TOX_ENV
+    tox_args = ["tox", "-l", "-c", "tox.ini"]
+    proc = subprocess.Popen(
+        tox_args,
+        cwd = execute_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL)
+    tox_env_list = proc.communicate()[0].decode()[:-1].split("\n")
+    return tox_env_list
+
+
+def matrix_scenarios():
+    ## シナリオのリスト (ansible role ディレクトリで定義されているもの)
+    scenarios_defined_by_role = [
+        os.path.basename(os.path.dirname(p)) for p
+        in glob.glob(repo_root_dir + "/../molecule/*/molecule.yml")
+        if os.path.isfile(p)
+    ]
+
+    ## シナリオのリスト (ansible-ci-module 内でデフォルトで定義してあるもの)
+    scenarios_in_ansible_ci_modules = [
+        os.path.basename(os.path.dirname(p)) for p
+        in glob.glob(repo_root_dir + "/molecule/*/molecule.yml")
+        if os.path.isfile(p)
+    ]
+
+    if len(scenarios_defined_by_role) >= 1:
+        return scenarios_defined_by_role
+    else:
+        return scenarios_in_ansible_ci_modules
+
+
+if __name__ == "__main__":
+    print("{" +
+        "\"tox_env\": [\"" + "\", \"".join(matrix_tox_envs()) + "\"], " +
+        "\"scenario\": [\"" + "\", \"".join(matrix_scenarios()) + "\"]" +
+        "}"
+    )

--- a/scripts/molecule.py
+++ b/scripts/molecule.py
@@ -8,50 +8,50 @@ if __name__ == "__main__":
 
     ## python script path and repo dir
     script_path   = os.path.abspath(__file__)
-    repo_root_dir = os.path.abspath(os.path.dirname(script_path) + "/..")
+    repo_root_dir = os.path.abspath(os.path.join(os.path.dirname(script_path), ".."))
 
 
     ## Execute dir
     __molecule_yml_files = [
-        p for p in glob.glob(repo_root_dir + "/../molecule/*/molecule.yml")
+        p for p in glob.glob(os.path.join(repo_root_dir, "..", "molecule", "*", "molecule.yml"))
         if os.path.isfile(p)]
     if len(__molecule_yml_files) >= 1:
-        execute_dir = os.path.abspath(repo_root_dir + "/..")
+        execute_dir = os.path.abspath(os.path.join(repo_root_dir, ".."))
     else:
         execute_dir = repo_root_dir
 
 
     ## Verify tests dir
     __tests_py_files = [
-        p for p in glob.glob(repo_root_dir + "/../molecule/common/tests/test_*.py")
+        p for p in glob.glob(os.path.join(repo_root_dir, "..", "molecule", "common", "tests", "test_*.py"))
         if os.path.isfile(p)]
     if len(__tests_py_files) >= 1:
-        tests_dir = os.path.abspath(repo_root_dir + "/../molecule/common/tests")
+        tests_dir = os.path.abspath(os.path.join(repo_root_dir, "..", "molecule", "common", "tests"))
     else:
-        tests_dir = repo_root_dir + "/molecule/common/tests"
+        tests_dir = os.path.join(repo_root_dir, "molecule", "common", "tests")
 
 
     ## group_vars
-    __group_vars_dir = repo_root_dir + "/../molecule/common/group_vars"
+    __group_vars_dir = os.path.join(repo_root_dir, "..", "molecule", "common", "group_vars")
     if os.path.exists(__group_vars_dir) and os.path.isdir(__group_vars_dir):
         group_vars_dir = os.path.abspath(__group_vars_dir)
     else:
-        group_vars_dir = repo_root_dir + "/molecule/common/group_vars"
+        group_vars_dir = os.path.join(repo_root_dir, "molecule", "common", "group_vars")
 
 
     ## Add env
     env = os.environ
-    env["CREATE_YML"]    = repo_root_dir + "/molecule/common/playbooks/create.yml"
-    env["DESTROY_YML"]   = repo_root_dir + "/molecule/common/playbooks/destroy.yml"
-    env["CONVERGE_YML"]  = repo_root_dir + "/molecule/common/playbooks/converge.yml"
-    env["HOST_VARS"]     = repo_root_dir + "/molecule/common/cache/host_vars/"
+    env["CREATE_YML"]    = os.path.join(repo_root_dir, "molecule", "common", "playbooks", "create.yml")
+    env["DESTROY_YML"]   = os.path.join(repo_root_dir, "molecule", "common", "playbooks", "destroy.yml")
+    env["CONVERGE_YML"]  = os.path.join(repo_root_dir, "molecule", "common", "playbooks", "converge.yml")
+    env["HOST_VARS"]     = os.path.join(repo_root_dir, "molecule", "common", "cache", "host_vars")
     env["GROUP_VARS"]    = group_vars_dir
     env["TESTINFRA_DIR"] = tests_dir
-    env["ROLE_DIR"]      = os.path.abspath(repo_root_dir + "/..")
+    env["ROLE_DIR"]      = os.path.abspath(os.path.join(repo_root_dir, ".."))
 
 
     ## Specify base.yml for molecule
-    base_yml_path = repo_root_dir + "/molecule/common/base.yml"
+    base_yml_path = os.path.join(repo_root_dir, "molecule", "common", "base.yml")
     args = sys.argv
     args[0] = "molecule"
     if (not "--base-config" in args) and (not "-c" in args):

--- a/scripts/molecule_test.py
+++ b/scripts/molecule_test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+if __name__ == "__main__":
+    import os
+    import subprocess
+    import sys
+
+    ## python script path and repo dir
+    script_dir  = os.path.dirname(os.path.abspath(__file__))
+    molecule_py = os.path.abspath(script_dir + "/molecule.py")
+
+    ## 環境変数の取得
+    env = os.environ
+    molecule_scenario = env.get("MOLECULE_SCENARIO")
+
+    ## molecule.py を実行する
+    if molecule_scenario == None:
+        args = [molecule_py, "test", "--all"]
+    else:
+        args = [molecule_py, "test", "-s", molecule_scenario]
+
+    print(" ".join(args))
+    proc = subprocess.run(args, env = env)
+    sys.exit(proc.returncode)

--- a/scripts/molecule_test.py
+++ b/scripts/molecule_test.py
@@ -3,6 +3,7 @@ if __name__ == "__main__":
     import os
     import subprocess
     import sys
+    import shlex
 
     ## python script path and repo dir
     script_dir  = os.path.dirname(os.path.abspath(__file__))
@@ -18,6 +19,6 @@ if __name__ == "__main__":
     else:
         args = [molecule_py, "test", "-s", molecule_scenario]
 
-    print(" ".join(args))
+    print(shlex.join(args))
     proc = subprocess.run(args, env = env)
     sys.exit(proc.returncode)

--- a/scripts/molecule_test.py
+++ b/scripts/molecule_test.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
 
     ## python script path and repo dir
     script_dir  = os.path.dirname(os.path.abspath(__file__))
-    molecule_py = os.path.abspath(script_dir + "/molecule.py")
+    molecule_py = os.path.abspath(os.path.join(script_dir, "molecule.py"))
 
     ## 環境変数の取得
     env = os.environ

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ passenv =
     HOME
     MOLECULE_DISTRO
     ANSIBLE_VER
+    MOLECULE_SCENARIO
 
 commands =
-    python3 ./scripts/molecule.py test --all
+    python3 ./scripts/molecule_test.py


### PR DESCRIPTION
@ledyba-z 
#3 の機能を実装したかったので, このプルリクを作成しました.
レビューしていただけると助かります.

参考として挙げている ansible-roles-v2_hello-world ではすでに使っていますので, 合わせて確認していただけると助かります.

### 概要
github actions におけるマトリックスジョブにおいて
```
「OS」×「ansible ver」×「molecule シナリオ」
```
での CI 実行をしやすくするために, 以下の変更をしました.

### 変更点

* github actions の matrix を json として標準出力するスクリプト `./scripts/matrix.py` を作成しました.
  単純に使うと以下のような出力が期待されます.
  ```
  $ python3 ./scripts/matrix.py
  {"tox_env": ["ubuntu1804-ansible28", "ubuntu1804-ansible29", "ubuntu2004-ansible28", "ubuntu2004-ansible29"], "scenario": ["double_instance", "default"]}
  ```
  ※ 上記の例は [ansible-roles-v2_hello-world](https://github.com/link-u/ansible-roles-v2_hello-world) でこのスクリプトを実行したもの.
  ※ github actions 内での使い方は[サンプルファイル](./github_workflow_samples/ansible-ci.yml)を確認してください.
  <br>


* 本モジュールを github actions で使用する際のサンプルファイルを用意しました.
  [ansible-ci.yml](./github_workflow_samples/ansible-ci.yml) を `<ansible role>/.github/workflows/` 以下に配置すれば ansible CI を github 上で実装できます.
  <br>


* tox コマンドを実行する際, 特定の molecule のシナリオを指定することができるよう `./scripts/molecule_test.py` を作成しました.
  またそれに伴い, tox.ini に以下の変更を加えました.
  * tox.ini の passenv に `MOLECULE_SCENARIO` を追加
  * tox.ini の commands を `python3 ./scripts/molecule_test.py` に変更

  これにより, tox コマンド実行時に molecule シナリオを環境変数 `MOLECULE_SCENARIO` として与えることによって, 特定の molecule シナリオを実行できます.
  ```
  # 例
  $ MOLECULE_SCENARIO=double_instance tox -e ubuntu2004-ansible29 -c ansible-ci-module/tox.ini
  ```

### 参考
* https://github.com/link-u/ansible-roles-v2_hello-world
* [ansible-roles-v2_hello-world にコミットした内容](https://github.com/link-u/ansible-roles-v2_hello-world/commit/7ca8c92db6dbbeb4f8eda1b7dc2fb17a11188220)

